### PR TITLE
Move protobuf generate command (pbjs) to npm script

### DIFF
--- a/generate-rnode-protos.sh
+++ b/generate-rnode-protos.sh
@@ -1,1 +1,0 @@
-sudo pbjs --keep-case -t static-module -w commonjs -o ./src/rnode-protos.js ./src/protobuf/*.proto && pbts -o src/rnode-protos.d.ts src/rnode-protos.js

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build:node": "npx rollup -c rollup.config.cjs.js",
     "compile": "tsc --module commonjs src/index.ts --outDir dist -d && cp -r src/protobuf dist/ && cp src/rnode-protos* dist/",
     "compile:tests": "cp -r src/protobuf testsc/src/ && cp src/rnode-protos.js testsc/src/ && tsc tests/index.ts --outDir testsc",
-    "compile:examples": "rm examples/*.js && tsc examples/*"
+    "compile:examples": "rm examples/*.js && tsc examples/*",
+    "generate": "pbjs --keep-case -t static-module -w commonjs -o ./src/rnode-protos.js ./src/protobuf/*.proto && pbts -o src/rnode-protos.d.ts src/rnode-protos.js"
   },
   "author": "FABCO",
   "license": "MIT",


### PR DESCRIPTION
## Overview

This PR moves command to generate JS and TS files from protobuf inside npm scripts and deletes existing bash script.

This has following benefits:
- Does not require user for globally installed `protobufjs` npm package with `pbjs` executable on PATH.
- Works also on Windows is shell is not available.